### PR TITLE
fix: Don't need no-undef for Typescript

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -10,6 +10,7 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": ["error"],
     "@typescript-eslint/semi": ["error", "always"],
     "@typescript-eslint/type-annotation-spacing": ["error"],
+    "@typescript-eslint/no-undef": "off",
     "@typescript-eslint/indent": [
       "error",
       2,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elementx-ai/eslint-config",
   "version": "7.2.0",
-  "description": "Spark 64's eslint config",
+  "description": "ElementX's ESLint Config",
   "license": "Unlicense",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Handled by Typescript

https://eslint.org/docs/latest/rules/no-undef#handled_by_typescript