### PR TITLE
fix: Turn off undef in TS, catch statement exceptions

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -27,14 +27,14 @@ export default [
     },
     plugins: {
       "prefer-arrow": preferArrow,
-      "import": _import,
+      import: _import,
       "@stylistic": stylistic,
     },
     rules: {
-      "complexity": ["error", 10],
-      "eqeqeq": ["error", "smart"],
-      "quotes": ["error", "double", { allowTemplateLiterals: true }],
-      "curly": ["error", "all"],
+      complexity: ["error", 10],
+      eqeqeq: ["error", "smart"],
+      quotes: ["error", "double", { allowTemplateLiterals: true }],
+      curly: ["error", "all"],
       "brace-style": ["error", "1tbs"],
       "eol-last": ["error", "always"],
       "space-in-parens": ["error", "never"],
@@ -53,7 +53,7 @@ export default [
       "generator-star-spacing": ["error", { before: false, after: true }],
       "arrow-spacing": ["error", { before: true, after: true }],
       "keyword-spacing": ["error", { before: true, after: true }],
-      "indent": [
+      indent: [
         "error",
         2,
         {
@@ -130,21 +130,28 @@ export default [
         "error",
         {
           "newlines-between": "always",
-          groups: ["external", "builtin", "internal", "sibling", "parent", "index"],
+          groups: [
+            "external",
+            "builtin",
+            "internal",
+            "sibling",
+            "parent",
+            "index",
+          ],
         },
       ],
       "padded-blocks": ["error", "never"],
     },
   },
   {
-    files: [
+    les: [
       "eslint.config.js",
       "*eslint.config.js",
       "**/eslint.config.js",
       "**/*eslint.config.js",
     ],
     plugins: {
-      "import": _import,
+      import: _import,
     },
     rules: {
       "import/no-default-export": "off",

--- a/lib/common.js
+++ b/lib/common.js
@@ -59,7 +59,6 @@ export default [
           destructuredArrayIgnorePattern: "^_",
           argsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",
-          varsIgnorePattern: "^_",
         },
       ],
       indent: [

--- a/lib/common.js
+++ b/lib/common.js
@@ -56,13 +56,10 @@ export default [
       "no-unused-vars": [
         "error",
         {
-          caughtErrors: "none",
-        },
-      ],
-      "no-empty": [
-        "error",
-        {
-          allowEmptyCatch: true,
+          destructuredArrayIgnorePattern: "^_",
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
         },
       ],
       indent: [

--- a/lib/common.js
+++ b/lib/common.js
@@ -150,7 +150,7 @@ export default [
     },
   },
   {
-    les: [
+    files: [
       "eslint.config.js",
       "*eslint.config.js",
       "**/eslint.config.js",

--- a/lib/common.js
+++ b/lib/common.js
@@ -53,6 +53,12 @@ export default [
       "generator-star-spacing": ["error", { before: false, after: true }],
       "arrow-spacing": ["error", { before: true, after: true }],
       "keyword-spacing": ["error", { before: true, after: true }],
+      "no-unused-vars": [
+        "error",
+        {
+          caughtErrors: "none",
+        },
+      ],
       indent: [
         "error",
         2,

--- a/lib/common.js
+++ b/lib/common.js
@@ -59,6 +59,12 @@ export default [
           caughtErrors: "none",
         },
       ],
+      "no-empty": [
+        "error",
+        {
+          allowEmptyCatch: true,
+        },
+      ],
       indent: [
         "error",
         2,

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -44,7 +44,10 @@ export default [
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
-          caughtErrors: "none",
+          destructuredArrayIgnorePattern: "^_",
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
         },
       ],
       "@typescript-eslint/naming-convention": [

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -4,12 +4,7 @@ import parser from "@typescript-eslint/parser";
 
 export default [
   {
-    files: [
-      "*.ts",
-      "*.tsx",
-      "**/*.ts",
-      "**/*.tsx",
-    ],
+    files: ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx"],
     languageOptions: {
       parser: parser,
       parserOptions: {
@@ -23,6 +18,7 @@ export default [
       "@typescript-eslint": typescript,
     },
     rules: {
+      "no-undef": "off",
       "@stylistic/type-annotation-spacing": ["error"],
       "@stylistic/indent": [
         "error",
@@ -46,7 +42,6 @@ export default [
       ],
       "@typescript-eslint/prefer-namespace-keyword": ["error"],
       "@typescript-eslint/no-unused-vars": ["error"],
-      "@typescript-eslint/no-undef": "off",
       "@typescript-eslint/naming-convention": [
         "error",
         {

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -41,7 +41,12 @@ export default [
         },
       ],
       "@typescript-eslint/prefer-namespace-keyword": ["error"],
-      "@typescript-eslint/no-unused-vars": ["error"],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          caughtErrors: "none",
+        },
+      ],
       "@typescript-eslint/naming-convention": [
         "error",
         {

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -47,7 +47,6 @@ export default [
           destructuredArrayIgnorePattern: "^_",
           argsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",
-          varsIgnorePattern: "^_",
         },
       ],
       "@typescript-eslint/naming-convention": [


### PR DESCRIPTION
You want to leave typescript parsers no undef and turn off the regular one here.
https://eslint.org/docs/latest/rules/no-undef
Recommends this because the typescript parser has its own way of resolving these. 
